### PR TITLE
Brew Tap formula for danger-swift

### DIFF
--- a/danger-swift.rb
+++ b/danger-swift.rb
@@ -4,17 +4,11 @@ class SourceDocs < Formula
   version "0.1.0"
   url "https://github.com/danger/danger-swift/archive/#{version}.tar.gz"
   sha256 "a9538c7d25ce1a58a01c0562a9902257e53e4bb396a2ab33ee69fb29e76845c4"
-  head "https://github.com/eneko/SourceDocs.git"
+  head "https://github.com/danger/danger-swift.git"
 
   depends_on :xcode
 
-  # def install
-  #   system "make", "install", "PREFIX=#{prefix}"
-  # end
   def install
-    build_path = "#{buildpath}/.build/release/sourcedocs"
-    ohai "Building SourceDocs"
-    system("swift --disable-sandbox build -c release -Xswiftc -static-stdlib")
-    bin.install build_path
+    system "make", "install"
   end
 end

--- a/danger-swift.rb
+++ b/danger-swift.rb
@@ -1,0 +1,20 @@
+class SourceDocs < Formula
+  desc "Write your Dangerfiles in Swift"
+  homepage "https://github.com/danger/danger-swift"
+  version "0.1.0"
+  url "https://github.com/danger/danger-swift/archive/#{version}.tar.gz"
+  sha256 "a9538c7d25ce1a58a01c0562a9902257e53e4bb396a2ab33ee69fb29e76845c4"
+  head "https://github.com/eneko/SourceDocs.git"
+
+  depends_on :xcode
+
+  # def install
+  #   system "make", "install", "PREFIX=#{prefix}"
+  # end
+  def install
+    build_path = "#{buildpath}/.build/release/sourcedocs"
+    ohai "Building SourceDocs"
+    system("swift --disable-sandbox build -c release -Xswiftc -static-stdlib")
+    bin.install build_path
+  end
+end


### PR DESCRIPTION
Tap formula for `danger-swift` command line tool. Once merged, users will be able to install with:
```
$ brew install danger/tap/danger-swift
```

In the future, if needed, we might want to push the formula to Homebrew-core, but that won't be needed in the short term.