### PR TITLE
Update danger-kotlin.rb to 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,8 @@ Contains the Danger homebrew formulae for:
   brew install danger/tap/danger-js 
   ```
   
-
+- Danger Kotlin
+  ```sh
+  brew install danger/tap/danger-kotlin
+  ```
+  

--- a/danger-kotlin.rb
+++ b/danger-kotlin.rb
@@ -1,9 +1,9 @@
 class DangerKotlin < Formula
   desc "Write your Dangerfiles in Kotlin"
   homepage "https://github.com/danger/kotlin"
-  version "0.7.0"
+  version "0.7.1"
   url "https://github.com/danger/kotlin/archive/#{version}.tar.gz"
-  sha256 "db54e7b5b045cd75d4e823d8e074ffc4b9beee113c9057d8d89c7fa4576341e9"
+  sha256 "ac54b2a0d7b15d9e2611778f76257c1fe10ef69d83305540873e9a64027e4e78"
   head "https://github.com/danger/kotlin.git"
 
   # Use the vendored danger


### PR DESCRIPTION
- Added brew instructions for danger-kotlin in README